### PR TITLE
Fixes for rune parser for OP.GG

### DIFF
--- a/Legendary Rune Maker/Pages/MainPage.xaml.cs
+++ b/Legendary Rune Maker/Pages/MainPage.xaml.cs
@@ -312,7 +312,6 @@ namespace Legendary_Rune_Maker.Pages
 
                                 LogTo.Debug("Setting page tree");
                                 Tree.SetPage(page);
-                                SelectedPosition = page.Position;
                             }
                             catch (Exception ex)
                             {

--- a/Legendary Rune Maker/Pages/MainPage.xaml.cs
+++ b/Legendary Rune Maker/Pages/MainPage.xaml.cs
@@ -312,6 +312,7 @@ namespace Legendary_Rune_Maker.Pages
 
                                 LogTo.Debug("Setting page tree");
                                 Tree.SetPage(page);
+                                SelectedPosition = page.Position;
                             }
                             catch (Exception ex)
                             {


### PR DESCRIPTION
- Added ability to get any role runes from OP.GG
- Fixed rune parsing (fragments)
- After loading of runes from any provider, selected position(line) will change correspondingly to loaded runes position(line)